### PR TITLE
Tiny fix for fatal bug

### DIFF
--- a/mkmpmp
+++ b/mkmpmp
@@ -1,0 +1,9 @@
+#!/usr/local/plan9/bin/rc
+
+cd mpmp
+mkdir -p bin
+javac -d bin `{du -a src | awk '{print $2}' | grep \.java }
+cd bin
+jar cfe mpmp.jar main.Main `{du -a | awk '{print $2}' | grep \.class }
+cd ../..
+mv mpmp/bin/mpmp.jar .

--- a/mpmp/src/main/Main.java
+++ b/mpmp/src/main/Main.java
@@ -13,10 +13,11 @@ import static main.SrvMain.srvmain;
  */
 public class Main {
 	public static void main(String[] args) {
-		if(args.length < 2)
+		if(args.length < 1)
 			usage();
 
-		switch(args[1]) {
+		// 0th argument is not the command in Java -oki
+		switch(args[0]) {
 		case "server":
 			srvmain(args);
 			break;


### PR DESCRIPTION
Apart from my pseudo-IDE script which had been deleted, this is just a small bugfix. In Java, the `args` array begins with the first _actual_ argument, not the invoking command. So our indices were one too high. That'd lead to an `ArrayOutOfBoundsException` were it not for the preceding if clause that just made it not do anything.
