### PR TITLE
Fix #39: not even a race condition

### DIFF
--- a/mpmp/src/cmds/ClientlistUpdate.java
+++ b/mpmp/src/cmds/ClientlistUpdate.java
@@ -30,6 +30,7 @@ public class ClientlistUpdate implements CmdFunc {
 		}
 
 		d.reset();
+		Player.reset();
 		while(nclients --> 0) {
 			String s;
 			String fields[];

--- a/mpmp/src/controller/Controller.java
+++ b/mpmp/src/controller/Controller.java
@@ -32,7 +32,7 @@ public class Controller {
 		Frame frame = new Frame(m);
 		Conn conn = new Conn(new Socket(addr, port));
 
-		Player.init();
+		Player.reset();
 
 		((ChatUpdate) Cmd.ChatUpdate.getFn()).addDisplayer(frame.chatDisp);
 		((ClientlistUpdate) Cmd.ClientlistUpdate.getFn()).addDisplayer(frame.playerDisp);

--- a/mpmp/src/main/Client.java
+++ b/mpmp/src/main/Client.java
@@ -29,6 +29,10 @@ public class Client extends Conn {
 	 * @return false on failure (name already used or nil), true otherwise
 	 */
 	public boolean subscribe(String color, Mode mode, String name) {
+		/* remove old Player from player list */
+		if(player != null)
+			player.remove();
+
 		if(name == null)
 			return false;
 
@@ -37,7 +41,7 @@ public class Client extends Conn {
 				return false;
 
 
-		this.player = new Player(Player.parseColor(color), mode, name);
+		player = new Player(Player.parseColor(color), mode, name);
 		return true;
 	}
 
@@ -68,6 +72,7 @@ public class Client extends Conn {
 	 */
 	public void remove() {
 		clients.remove(this);
+		player.remove();
 		listClients();
 	}
 

--- a/mpmp/src/main/Client.java
+++ b/mpmp/src/main/Client.java
@@ -101,9 +101,9 @@ public class Client extends Conn {
 	}
 
 	/**
-	 * Initialise the client table.
+	 * Reset the client table.
 	 */
-	public static void init() {
+	public static void reset() {
 		clients = new HashSet<>();
 	}
 	

--- a/mpmp/src/main/SrvMain.java
+++ b/mpmp/src/main/SrvMain.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package main;
 
 import java.io.IOException;
@@ -12,14 +7,15 @@ import java.net.Socket;
 import model.Player;
 
 /**
+ * Main class of the server.
  *
- * @author leander.dreier
+ * @author Leander, oki
  */
 public class SrvMain {
 	public static void srvmain(String[] args) {
 		ServerSocket listener;
-		Client.init();
-		Player.init();
+		Client.reset();
+		Player.reset();
 
 		try {
 			listener = new ServerSocket(1918);

--- a/mpmp/src/model/Player.java
+++ b/mpmp/src/model/Player.java
@@ -26,10 +26,9 @@ public class Player {
 	private String name;
 	private Color color;
 	private Mode mode;
-
-	/* only active players */
 	private static HashSet<Player> players;
 
+	/* only active players */
 	private HashSet<Plot> plots;
 	private HashSet<Plot> hypothecs;
 	private int cash;                         /* actual liquid money */
@@ -42,8 +41,10 @@ public class Player {
 		this.name = name;
 		this.color = color;
 		this.mode = mode;
-		
-		players.add(this);
+
+		synchronized(players) {
+			players.add(this);
+		}
 		
 		if(mode == Mode.Player) {
 			plots = new HashSet<>();
@@ -66,6 +67,12 @@ public class Player {
 		// Convert to hex triplet without alpha value and in uppercase.
 		String col = "#" + Integer.toHexString(color.getRGB()).substring(2).toUpperCase();
 		return col + ": " + mode + ": " + name;
+	}
+
+	public void remove() {
+		synchronized(players) {
+			players.remove(this);
+		}
 	}
 
 	/* GAME LOGIC */
@@ -127,10 +134,12 @@ public class Player {
 	}
 
 	/**
-	 * Give up and auction everything of value.
+	 * Give up and auction everything of value and delete from player list.
 	 */
 	public void ragequit() {
-		// XXX auction all the plots and houses the player had 
+		// XXX auction all the plots and houses the player had
+		// We'll be replaced by a fresh spectator Player, so remove ourselves.
+		remove();
 	}
 
 	
@@ -246,7 +255,7 @@ public class Player {
 			return Color.BLACK;  // XXX default color - randomise
 		}
 	}
-	
+
 	public static int numPlayers() {
 		return players.size();
 	}

--- a/mpmp/src/model/Player.java
+++ b/mpmp/src/model/Player.java
@@ -239,9 +239,10 @@ public class Player {
 	/* STATIC */
 
 	/**
-	 * Initialise the player table.
+	 * Reset the player table. Called on start. In the client, this is also called
+	 * when a clientlist-update comes in.
 	 */
-	public static void init() {
+	public static void reset() {
 		players = new HashSet<>();
 	}
 


### PR DESCRIPTION
We simply forgot to remove non-existing players from the list, AFAIK. To deal with it, I added a `remove` method in `Player` that is called when its Client is removed (connection breaks), its Player is replaced by a spectator (ragequits), or when the user resubscribes.

Whereever `new Player()` appears, we need to take care to remove the old instance if there is one. Garbage collection doesn't work here because there is always reference in `Player.players`.
