### PR TITLE
Plot system revamp

### DIFF
--- a/mpmp/src/cmds/AddHouse.java
+++ b/mpmp/src/cmds/AddHouse.java
@@ -1,23 +1,26 @@
 package cmds;
 
 import java.util.Arrays;
+
 import main.Client;
 import main.Conn;
 import main.ErrCode;
 import model.Player;
 import model.Plot;
+import model.HousePlot;
 
 /**
  * C->S
  * @author Leander
  */
 public class AddHouse implements CmdFunc {
-
 	@Override
 	public void exec(String line, Conn conn) {
+		Player p;
+		HousePlot hp;
 		String[] args = line.split(" ");
 
-		Player p = Player.search(((Client) conn).getName());
+		p = Player.search(((Client) conn).getName());
 		if (!p.isPlayer()) {
 			conn.sendErr(ErrCode.NotAPlayer);
 			return;
@@ -28,18 +31,18 @@ public class AddHouse implements CmdFunc {
 			return;
 		}
 
-		Plot plot = Plot.search(String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
-		if (plot == null) {
+		hp = (HousePlot) Plot.search(String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
+		if (hp == null) {
 			conn.sendErr(ErrCode.NotAPlot);
 			return;
 		}
 
-		if (plot.getOwner() != p) {
-			conn.sendErr(ErrCode.AlreadyOwned, plot.getOwner().getName());
+		if (hp.getOwner() != p) {
+			conn.sendErr(ErrCode.AlreadyOwned, hp.getOwner().getName());
 			return;
 		}
 
-		switch (plot.addHouse()) {
+		switch (hp.addHouse()) {
 		case -1:
 			conn.sendErr(ErrCode.TooManyHouses);
 			return;
@@ -54,8 +57,8 @@ public class AddHouse implements CmdFunc {
 			return;
 		case 1:
 			conn.sendOK();
-			conn.send("show-transaction " + plot.getHousePrice(plot.getHouses()) + " Buy house for plot " + plot.getName());
-			conn.send("plot-update " + plot.getName() + " " + plot.getHouses() + " " + plot.isHypothec() + plot.getOwner());
+			conn.send("show-transaction " + hp.getHousePrice(hp.getHouses()) + " Buy house for plot " + hp.getName());
+			Client.broadcast("plot-update " + hp);
 			break;
 		default:
 			conn.sendErr(ErrCode.Internal, "Unexpected error");
@@ -66,5 +69,4 @@ public class AddHouse implements CmdFunc {
 	public void error(ErrCode err, String line, Conn conn) {
 		//TODO
 	}
-	
 }

--- a/mpmp/src/cmds/RmHouse.java
+++ b/mpmp/src/cmds/RmHouse.java
@@ -1,20 +1,22 @@
 package cmds;
 
 import java.util.Arrays;
+
 import main.Client;
 import main.Conn;
 import main.ErrCode;
 import model.Player;
 import model.Plot;
+import model.HousePlot;
 
 /**
  * C->S
  * @author Leander
  */
 public class RmHouse implements CmdFunc {
-
 	@Override
 	public void exec(String line, Conn conn) {
+		HousePlot hp;
 		String[] args = line.split(" ");
 
 		Player p = Player.search(((Client) conn).getName());
@@ -28,18 +30,18 @@ public class RmHouse implements CmdFunc {
 			return;
 		}
 
-		Plot plot = Plot.search(String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
-		if (plot == null) {
+		hp = (HousePlot) Plot.search(String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
+		if (hp == null) {
 			conn.sendErr(ErrCode.NotAPlot);
 			return;
 		}
 
-		if (plot.getOwner() != p) {
-			conn.sendErr(ErrCode.AlreadyOwned, plot.getOwner().getName());
+		if (hp.getOwner() != p) {
+			conn.sendErr(ErrCode.AlreadyOwned, hp.getOwner().getName());
 			return;
 		}
 		
-		switch (plot.rmHouse()) {
+		switch (hp.rmHouse()) {
 		case -1:
 			conn.sendErr(ErrCode.DontHave, "a single house");
 			return;
@@ -48,19 +50,16 @@ public class RmHouse implements CmdFunc {
 			return;
 		case 1:
 			conn.sendOK();
-			conn.send("show-transaction " + plot.getHousePrice(plot.getHouses()+1)/2 + " Sell house for plot " + plot.getName());
-			conn.send("plot-update " + plot.getName() + " " + plot.getHouses() + " " + plot.isHypothec() + plot.getOwner());
+			conn.send("show-transaction " + hp.getHousePrice(hp.getHouses()+1)/2 + " Sell house for plot " + hp.getName());
+			conn.send("plot-update " + hp);
 			break;
 		default:
 			conn.sendErr(ErrCode.Internal, "Unexpected error");
-		}
-		
-		
+		}	
 	}
 
 	@Override
 	public void error(ErrCode err, String line, Conn conn) {
 		//TODO
 	}
-	
 }

--- a/mpmp/src/cmds/SellPlot.java
+++ b/mpmp/src/cmds/SellPlot.java
@@ -12,15 +12,17 @@ import view.Displayer;
  * C->S
  * @author Leander
  */
-public class SellPlot implements CmdFunc{
+public class SellPlot implements CmdFunc {
 	private Displayer d;
 
 	@Override
 	public void exec(String line, Conn conn) {
+		Player p;
+		Plot plot;
 		String[] args = line.split(" ");
 		int price = -1;
 
-		Player p = Player.search(((Client) conn).getName());
+		p = Player.search(((Client) conn).getName());
 		if (!p.isPlayer()) {
 			conn.sendErr(ErrCode.NotAPlayer);
 			return;
@@ -37,14 +39,13 @@ public class SellPlot implements CmdFunc{
 			return;
 		}
 
-		Plot plot = Plot.search(plotname);
-
+		plot = Plot.search(plotname);
 		if (p != plot.getOwner()) {
 			conn.sendErr(ErrCode.AlreadyOwned, plot.getOwner().getName());
 			return;
 		}
 
-		if (plot.getHouses() != 0) {
+		if (!plot.canSell()) {
 			conn.sendErr(ErrCode.PlotWithHouse);
 			return;
 		}
@@ -76,7 +77,7 @@ public class SellPlot implements CmdFunc{
 
 		conn.sendOK();
 		conn.send("show-transaction " + price + " Resell plot " + plot.getName());
-		conn.send("plot-update " + plot.getName() + " " + plot.getHouses() + " " + plot.isHypothec() + plot.getOwner());
+		Client.broadcast("plot-update " + plot);
 	}
 
 	@Override

--- a/mpmp/src/model/HousePlot.java
+++ b/mpmp/src/model/HousePlot.java
@@ -1,0 +1,85 @@
+package model;
+
+/**
+ * Your ordinary plot that you can build houses on, mark as hypothec
+ *
+ * @author oki, Leander
+ */
+public class HousePlot extends Plot {
+	public static final int MaxHouses = 5;   /* hotel counts as five houses */
+
+	private final int rent[];         /* six entries: plot alone, with one house, two houses, ..., hotel */
+	private final int housePrices[];
+	private int houses;
+
+	public HousePlot(PlotGroup group, String name, int price, int[] rent, int[] housePrices) {
+		super(group, name, price);
+
+		this.rent = rent;
+		this.housePrices = housePrices;
+	}
+	
+	public int getHousePrice(int houses) {
+		return housePrices[houses];
+	}
+
+	@Override
+	public int getHouses() {
+		return houses;
+	}
+
+	@Override
+	public boolean canSell() {
+		if(houses > 0)
+			return false;
+
+		return true;
+	}
+
+	/**
+	 * Add a house to the street, if possible.
+	 */
+	public int addHouse() {
+		// One hotel per street.
+		if(houses == 5)
+			return -1;
+
+		if(group.canAddHouse(owner, this) != 1)
+			return group.canAddHouse(owner, this);
+
+		if(!owner.addMoney(-housePrices[houses])) {
+			return -4;
+		}
+		
+		houses++;
+		return 1;
+	}
+
+	/**
+	 * Remove a house and give it back to the bank for half the price.
+	 */
+	public int rmHouse() {
+		if (houses == 0)
+			return -1;
+
+		if(!group.canRmHouse(owner, this))
+			return -2;
+
+		owner.addMoney(housePrices[houses]/2);
+		return 1;
+	}
+
+	/**
+	 * Make the visitor PAY for staying on our lands! Mwahahah
+	 */
+	@Override
+	public int payRent(Player visitor) {
+		int r = rent[houses];
+
+		if(hypothec)
+			return 0;
+
+		visitor.addMoney(-r);
+		return r;
+	}
+}

--- a/mpmp/src/model/PlotGroup.java
+++ b/mpmp/src/model/PlotGroup.java
@@ -23,27 +23,49 @@ public class PlotGroup {
 	}
 
 	/**
-	 * Tells whether the player can actually build a house on this plot.
+	 * @return true when a house can be built on the plot.
 	 */
-	public int canAddHouse(Player p, Plot plot) {
+	public int canAddHouse(Player p, HousePlot plot) {
 		for(Plot pl : plots) {
+			HousePlot hp = (HousePlot) pl;
+
 			// You must control all plots in the group.
-			if(pl.getOwner() != p)
+			if(hp.getOwner() != p)
 				return -2;
 
 			// You can't build a house if another plot of the group has fewer houses already.
-			if(pl.getHouses() < plot.getHouses())
+			if(hp.getHouses() < plot.getHouses())
 				return -3;
 		}
 
 		return 1;	
 	}
 
-	public boolean canRmHouse(Player p, Plot plot) {
-		for (Plot pl : plots)
-			if (pl.getHouses() > plot.getHouses())
+	/**
+	 * @return true when house can be removed.
+	 */
+	public boolean canRmHouse(Player p, HousePlot plot) {
+		for (Plot pl : plots) {
+			HousePlot hp = (HousePlot) pl;
+			if (hp.getHouses() > plot.getHouses())
 				return false;
+		}
+
 		return true;
+	}
+
+	/**
+	 * @return number of plots in the group owned by a player.
+	 */
+	public int plotsOwned(Player p) {
+		int n;
+
+		n = 0;
+		for(Plot pl : plots)
+			if(pl.owner == p)
+				n++;
+
+		return n;
 	}
 
 	private void add(Plot p) {

--- a/mpmp/src/model/TrainStation.java
+++ b/mpmp/src/model/TrainStation.java
@@ -1,0 +1,24 @@
+package model;
+
+public class TrainStation extends Plot {
+	private static final int baseRent = 500; // XXX value
+
+	public TrainStation(PlotGroup group, String name, int price) {
+		super(group, name, price);
+	}
+
+	@Override
+	public int payRent(Player visitor) {
+		int r;
+		int n;
+
+		/* Double the rent for every owned station. */
+		r = baseRent;
+		n = group.plotsOwned(owner);
+		for(int i = 0; i < n; i++)
+			r *= 2;
+
+		visitor.addMoney(-r);
+		return r;
+	}
+}


### PR DESCRIPTION
`Plot` is now abstract and delegates `payRent`, `getHouses` and `canSell` into its subclasses `HousePlot` and `TrainStation`.

The packet code for `add-money`, `rm-money` and `sell-plot` was updated accordingly while fixing a grave bug (@leletec used `conn.send` for the update packets instead of broadcasting; the protocol isn't very clear 'bout that).

Other changes:
- added a `canSell` method instead of testing in sell-plot directly → _abstraction_
- added a `toString` method to `Plot`. It returns the string required by `plot-update`.
