### PR TITLE
Fix instant disconnect

### DIFF
--- a/mpmp/src/cmds/Subscribe.java
+++ b/mpmp/src/cmds/Subscribe.java
@@ -22,6 +22,7 @@ public class Subscribe implements CmdFunc {
 		
 		if (GameState.running()) {
 			conn.sendErr(ErrCode.GameRunning);
+			return;
 		}
 		
 		args = line.split(" ");

--- a/mpmp/src/main/GameState.java
+++ b/mpmp/src/main/GameState.java
@@ -7,15 +7,15 @@ package main;
 public enum GameState {
 	Pregame, RunningGame;
 
-	private static GameState state;
+	private static GameState state = Pregame;
 
 	public static void startGame() {
 		state = RunningGame;
 	}
 
 	public static boolean running() {
-		if (state == Pregame)
-			return false;
-		return true;
+		if (state == RunningGame)
+			return true;
+		return false;
 	}
 }


### PR DESCRIPTION
A missing return caused `Subscribe` to always fail.
