### PR TITLE
Fix #144

### DIFF
--- a/mpmp/src/view/Frame.java
+++ b/mpmp/src/view/Frame.java
@@ -166,6 +166,8 @@ public class Frame extends JFrame implements Subscribe.SubscribeErrer {
 
 		pBelowChat.add(bClearChat);
 		pBelowChat.add(bEndTurn);
+		tChatField.setMinimumSize(new Dimension(300, 40));
+		tChatField.setMaximumSize(new Dimension(300, 60));
 
 		pChat.add(spChatBox);
 		pChat.add(tChatField);


### PR DESCRIPTION
See #144. I noticed this problem on a Windows 10 box and can't actually reproduce it on my system, but the fix doesn't break the layout. If Java and Swing behaved as one could expect (which it doesn't), the fix should be fine.
