### PR TITLE
Fix #143: off-by-one dice roll

### DIFF
--- a/mpmp/src/model/Diceroll.java
+++ b/mpmp/src/model/Diceroll.java
@@ -34,7 +34,7 @@ public class Diceroll {
 		int rolls[] = new int[Ndice];
 
 		for(int i = 0; i < Ndice; i++)
-			rolls[i] = r.nextInt(Nfaces+1) + 1;  /* between 1 and Nfaces */
+			rolls[i] = r.nextInt(Nfaces) + 1;  /* between 1 and Nfaces */
 
 		/* check for pasches (whether all rolls are the same) */
 		int r0 = rolls[0];


### PR DESCRIPTION
Error like this happen when you're ignorant of the documentation. It clearly states that the number generated ranges from`[0; bound[`. **Mea culpa**
