### PR TITLE
Add eventcard packet, fix non-bug

### DIFF
--- a/mpmp/src/client/Controller.java
+++ b/mpmp/src/client/Controller.java
@@ -22,6 +22,7 @@ import net.ShowTransaction;
 import net.Cmd;
 import net.Conn;
 import net.ChatUpdate;
+import net.Eventcard;
 import net.MoneyUpdate;
 import net.PlayerlistUpdate;
 import net.PlotUpdate;
@@ -63,6 +64,7 @@ implements MoneyUpdater, PosUpdater, TurnUpdater, PrisonUpdater, StartUpdater, P
 
 		/* Please insert alphabetically. -oki */
 		((ChatUpdate) Cmd.ChatUpdate.getFn()).addDisplayer(frame.chatDisp);
+		((Eventcard) Cmd.Eventcard.getFn()).addDisplayer(frame.chatDisp);
 		((MoneyUpdate) Cmd.MoneyUpdate.getFn()).addMoneyUpdater(this);
 		((PlayerlistUpdate) Cmd.PlayerlistUpdate.getFn()).addPlayerlistUpdater(this);
 		((PlotUpdate) Cmd.PlotUpdate.getFn()).addPlotUpdater(this);

--- a/mpmp/src/model/Card.java
+++ b/mpmp/src/model/Card.java
@@ -8,7 +8,6 @@ import java.util.Random;
  * Event cards.
  */
 public class Card {
-
 	private static Random randomno;
 	private static ArrayList<Card> eventCards;
 	private static ArrayList<Card> communityCards;
@@ -54,6 +53,10 @@ public class Card {
 			}
 
 		}
+	}
+
+	public String toString() {
+		return text;
 	}
 
 	public static Card getRandomCard(boolean eventcards) {

--- a/mpmp/src/model/SrvPlayer.java
+++ b/mpmp/src/model/SrvPlayer.java
@@ -151,17 +151,22 @@ public class SrvPlayer {
 			addMoney(Wage);
 		}
 
+		Card card;
 		switch (pos) {
 			case Field.EventField1:
 			case Field.EventField2:
 			case Field.EventField3:
-				Card.getRandomCard(true).run(this);
+				card = Card.getRandomCard(true);
+				Update.eventcard(this, card);
+				card.run(this);
 				break;
 
 			case Field.CommunityField1:
 			case Field.CommunityField2:
 			case Field.CommunityField3:
-				Card.getRandomCard(false).run(this);
+				card = Card.getRandomCard(true);
+				Update.eventcard(this, card);
+				card.run(this);
 				break;
 
 			case Field.IncomeTax:
@@ -189,7 +194,11 @@ public class SrvPlayer {
 				break;
 
 			default:
-				SrvModel.self.m.getPlot(pos).payRent(this);
+				Plot plot = SrvModel.self.m.getPlot(pos);
+				if(plot == null)
+					System.out.println("unimplemented plot " + pos);
+				else
+					plot.payRent(this);
 				break;
 		}
 

--- a/mpmp/src/net/Cmd.java
+++ b/mpmp/src/net/Cmd.java
@@ -29,7 +29,8 @@ public enum Cmd {
 	PosUpdate("pos-update", new PosUpdate()),
 	MoneyUpdate("money-update", new MoneyUpdate()),
 	TurnUpdate("turn-update", new TurnUpdate()),
-	StartUpdate("start-update", new StartUpdate());
+	StartUpdate("start-update", new StartUpdate()),
+	Eventcard("eventcard", new Eventcard());
 
 	private final String s;
 	private final CmdFunc fn;

--- a/mpmp/src/net/Eventcard.java
+++ b/mpmp/src/net/Eventcard.java
@@ -1,0 +1,24 @@
+package net;
+
+import view.Displayer;
+
+/** eventcard S->C display-only packet */
+public class Eventcard implements CmdFunc {
+	private Displayer d;
+
+	@Override
+	public void exec(String line, Conn conn) {
+		String descr;
+
+		descr = line.substring("eventcard".length());
+		descr = descr.trim();
+		d.show(descr);
+	}
+
+	@Override
+	public void error(ErrCode err, String line, Conn conn) {}
+
+	public void addDisplayer(Displayer d) {
+		this.d = d;
+	}
+}

--- a/mpmp/src/srv/Update.java
+++ b/mpmp/src/srv/Update.java
@@ -1,5 +1,6 @@
 package srv;
 
+import model.Card;
 import model.SrvPlayer;
 
 /**
@@ -20,5 +21,10 @@ public class Update {
 	public static void transact(SrvPlayer recv, int sum, String reason) {
 		Client.broadcast("money-update " + recv.p.getMoney() + " " + recv.p.getName());
 		(Client.search(recv.p.getName())).send("show-transaction " + sum + " " + reason);
+	}
+
+	/* Only sent to sp; technically not an update packet. */
+	public static void eventcard(SrvPlayer sp, Card c) {
+		(Client.search(sp.p.getName())).send("eventcard " + c);
 	}
 }


### PR DESCRIPTION
**Improvements**
- When you step on an eventcard field, the message is displayed in the chat box.
- When you end up on a not yet registered plot, the server doesn't crash. Crashing is the appropiate answer to unregistered plots, but it was annoying. Now, a message is printed on the server console in this case.

**Bugs**
- Picking a different eventcard is not implemented (`133` error).
