### PR TITLE
Fix crash, minor UI tweaks

### DIFF
--- a/mpmp/src/client/Controller.java
+++ b/mpmp/src/client/Controller.java
@@ -8,7 +8,6 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.util.Timer;
@@ -102,82 +101,55 @@ implements MoneyUpdater, PosUpdater, TurnUpdater, PrisonUpdater, StartUpdater, P
 			}
 		});
 
-		frame.addSurrenderListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addSurrenderListener((ActionEvent e) -> {
 				conn.send("ragequit");
 				frame.showQuitButton();
 				frame.addSurrenderListener((ActionEvent ev) -> {System.exit(0);});
-			}
-		});
+			});
 
-		frame.addEndTurnListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addEndTurnListener((ActionEvent e) -> {
 				if (m.running())
 					conn.send("end-turn");
 				else
 					conn.send("start-game");
-			}
-		});
+			});
 
-		frame.addUpdatePlayerListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addUpdatePlayerListener((ActionEvent e) -> {
 				frame.myPlayerDisp.show(Player.search(name));
-			}
-		});
+			});
 
-		frame.addTradeListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addTradeListener((ActionEvent e) -> {
 				System.out.println(frame.showDialog("Welcher Spieler"));
 				System.out.println(frame.showDialog("Welches Grundstück"));
-			}
-		});
+			});
 
-		frame.addBuyHouseListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addBuyHouseListener((ActionEvent e) -> {
 				Player p = m.getPlayer(myName);
 				// XXX this is a UX nightmare
 				int plotpos = Integer.parseInt(frame.showDialog("Grundstücksnummer pls"));
 				conn.send("add-house " + plotpos);
 				// XXX show answer by handling error in AddHouse
-			}
-		});
+			});
 
-		frame.addBuyPlotListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addBuyPlotListener((ActionEvent e) -> {
 				Player p = m.getPlayer(myName);
 				conn.send("buy-plot " + p.getPos() + " " + p.getName());
 				// XXX show answer by handling error in BuyPlot
-			}
-		});
+			});
 
-		frame.addPayPrisonListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addPayPrisonListener((ActionEvent e) -> {
 				conn.send("unjail money");
 				// XXX show answer by handling error in Unjail
-			}
-		});
+			});
 
-		frame.addUsePrisonLeaveListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addUsePrisonLeaveListener((ActionEvent e) -> {
 				conn.send("unjail card");
 				// XXX show answer by handling error in Unjail
-			}
-		});
+			});
 
-		frame.addClearChatListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		frame.addClearChatListener((ActionEvent e) -> {
 				frame.chatDisp.reset();
-			}
-		});
+			});
 	}
 
 	/* S->C UPDATES */

--- a/mpmp/src/client/Controller.java
+++ b/mpmp/src/client/Controller.java
@@ -106,6 +106,8 @@ implements MoneyUpdater, PosUpdater, TurnUpdater, PrisonUpdater, StartUpdater, P
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				conn.send("ragequit");
+				frame.showQuitButton();
+				frame.addSurrenderListener((ActionEvent ev) -> {System.exit(0);});
 			}
 		});
 

--- a/mpmp/src/net/EndTurn.java
+++ b/mpmp/src/net/EndTurn.java
@@ -30,6 +30,8 @@ public class EndTurn implements CmdFunc {
 		}
 
 		sp = sm.getSrvPlayer(sm.m.getCurrentPlayer());
+		if(sp == null)
+			return; /* no current player! */
 
 		// Only current player can end their turn.
 		if(!c.getName().equals(sp.p.getName()))

--- a/mpmp/src/net/ShowTransaction.java
+++ b/mpmp/src/net/ShowTransaction.java
@@ -15,11 +15,11 @@ public class ShowTransaction implements CmdFunc {
 	public void exec(String line, Conn conn) {
 		String reason;
 		String args[];
+		Color col;
 		int amount;
 
 		args = line.split(" ");
 		if(args.length < 3) {
-			// XXX one syntax/usage error code should suffice -oki
 			conn.sendErr(ErrCode.Usage, "show-transaction <amount> <reason>");
 			return;
 		}
@@ -32,7 +32,13 @@ public class ShowTransaction implements CmdFunc {
 		}
 
 		reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-		d.show("show-transaction: " + amount + " " + reason, Color.RED);
+
+		if(amount < 0)
+			col = Color.RED;
+		else
+			col = new Color(144, 238, 144); /* X11 Light green (#90EE90) */
+
+		d.show("show-transaction: " + amount + " " + reason, col);
 	}
 
 	@Override

--- a/mpmp/src/view/Frame.java
+++ b/mpmp/src/view/Frame.java
@@ -266,6 +266,11 @@ public class Frame extends JFrame implements Subscribe.SubscribeErrer {
 		return gameboard.showPrompt(msg);
 	}
 
+	/* Repurpose the Surrender button to quit the game. */
+	public void showQuitButton() {
+		bSurrender.setText("BEENDEN");
+	}
+
 	/**
 	 * Append text to a text pane in that color and boldness.
 	 */


### PR DESCRIPTION
- Fix crash that occurs when the `EndTurn` code compares the evoker to the current player; the current player may be null.
- Show positive transactions in light green.
- Reuse Surrender button as Quit button.
- Replace `ActionListener`s with lambda expressions. I couldn't not do that, it's so much better to have function literals.
