### PR TITLE
Implement unchecked plot-selling

### DIFF
--- a/mpmp/src/client/Controller.java
+++ b/mpmp/src/client/Controller.java
@@ -119,8 +119,25 @@ implements MoneyUpdater, PosUpdater, TurnUpdater, PrisonUpdater, StartUpdater, P
 			});
 
 		frame.addTradeListener((ActionEvent e) -> {
-				System.out.println(frame.showDialog("Welcher Spieler"));
-				System.out.println(frame.showDialog("Welches Grundstück"));
+				String buyer;
+				int pos;
+				int amount;
+
+				try {
+					pos = Integer.parseInt(frame.showDialog("Grundstücksnummer pls"));
+					amount = Integer.parseInt(frame.showDialog("Wieviel soll's kosten?"));
+				} catch(NumberFormatException nfe) {
+					frame.chatDisp.show("Dat is keine Zahl gewesen!", Color.ORANGE);
+					return;
+				}
+
+				buyer = frame.showDialog("Wer ist der Käufer?");
+				if(m.getPlayer(buyer) == null) {
+					frame.chatDisp.show("Diesen Spieler gibt's nicht mal!", Color.ORANGE);
+					return;
+				}
+
+				conn.send("sell-plot " + pos + " " + amount + " " + buyer);
 			});
 
 		frame.addBuyHouseListener((ActionEvent e) -> {


### PR DESCRIPTION
You can now trade plots with other players. It is unchecked because the buyer can't decline the offer. I repeat: At the moment you can buy any plot and sell it to another player for their entire money and they can't do anything to prevent it. Wonderfully broken.
